### PR TITLE
Control Optitrack from trigger services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,14 @@ find_package(rclcpp REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 
 include_directories(include
   ${rclcpp_INCLUDE_DIRS}
   ${tf2_ros_INCLUDE_DIRS}
   ${geometry_msgs_INCLUDE_DIRS}
   ${nav_msgs_INCLUDE_DIRS}
+  ${std_srvs_INCLUDE_DIRS}
 )
 
 add_subdirectory(src)

--- a/include/mocap_optitrack/rigid_body_publisher.h
+++ b/include/mocap_optitrack/rigid_body_publisher.h
@@ -88,9 +88,12 @@ public:
     const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
     std::shared_ptr<std_srvs::srv::Trigger::Response> response);
 
+  bool shouldPublishFrame() const { return shouldPublish; }
+
 private:
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr startServicePtr;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr stopServicePtr;
+  bool shouldPublish = true;
 };
 
 /// \brief Dispatches RigidBody data to the correct publisher.

--- a/include/mocap_optitrack/rigid_body_publisher.h
+++ b/include/mocap_optitrack/rigid_body_publisher.h
@@ -94,6 +94,8 @@ private:
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr startServicePtr;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr stopServicePtr;
   bool shouldPublish = true;
+
+  rclcpp::Logger logger_;
 };
 
 /// \brief Dispatches RigidBody data to the correct publisher.

--- a/include/mocap_optitrack/rigid_body_publisher.h
+++ b/include/mocap_optitrack/rigid_body_publisher.h
@@ -96,6 +96,7 @@ private:
   bool shouldPublish = true;
 
   rclcpp::Logger logger_;
+  PublisherConfiguration config;
 };
 
 /// \brief Dispatches RigidBody data to the correct publisher.

--- a/include/mocap_optitrack/rigid_body_publisher.h
+++ b/include/mocap_optitrack/rigid_body_publisher.h
@@ -38,6 +38,8 @@
 #include <rclcpp/time.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 
+#include "std_srvs/srv/trigger.hpp"
+
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose2_d.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -72,12 +74,35 @@ private:
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odomPublisher;
 };
 
+class TriggerServiceHandler
+{
+public:
+  TriggerServiceHandler(rclcpp::Node::SharedPtr &node, PublisherConfiguration const& config);
+  ~TriggerServiceHandler();
+
+  void startTriggerCallback(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+
+  void stopTriggerCallback(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+
+private:
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr startServicePtr;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr stopServicePtr;
+};
+
 /// \brief Dispatches RigidBody data to the correct publisher.
 class RigidBodyPublishDispatcher
 {
     typedef std::shared_ptr<RigidBodyPublisher> RigidBodyPublisherPtr;
     typedef std::map<int,RigidBodyPublisherPtr> RigidBodyPublisherMap;
     RigidBodyPublisherMap rigidBodyPublisherMap;
+
+    typedef std::shared_ptr<TriggerServiceHandler> TriggerServicePtr;
+    typedef std::map<int,TriggerServicePtr> TriggerServiceMap;
+    TriggerServiceMap triggerServiceMap;
 
 public:
     RigidBodyPublishDispatcher(rclcpp::Node::SharedPtr &node, 

--- a/include/mocap_optitrack/rigid_body_publisher.h
+++ b/include/mocap_optitrack/rigid_body_publisher.h
@@ -38,7 +38,7 @@
 #include <rclcpp/time.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 
-#include "std_srvs/srv/trigger.hpp"
+#include "std_srvs/srv/set_bool.hpp"
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose2_d.hpp>
@@ -74,25 +74,20 @@ private:
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odomPublisher;
 };
 
-class TriggerServiceHandler
+class EnableServiceHandler
 {
 public:
-  TriggerServiceHandler(rclcpp::Node::SharedPtr &node, PublisherConfiguration const& config);
-  ~TriggerServiceHandler();
+  EnableServiceHandler(rclcpp::Node::SharedPtr &node, PublisherConfiguration const& config);
+  ~EnableServiceHandler();
 
-  void startTriggerCallback(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response);
-
-  void stopTriggerCallback(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+  void setBoolServiceCallback(
+    const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+    std::shared_ptr<std_srvs::srv::SetBool::Response> response);
 
   bool shouldPublishFrame() const { return shouldPublish; }
 
 private:
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr startServicePtr;
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr stopServicePtr;
+  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr servicePtr;
   bool shouldPublish = true;
 
   rclcpp::Logger logger_;
@@ -106,9 +101,9 @@ class RigidBodyPublishDispatcher
     typedef std::map<int,RigidBodyPublisherPtr> RigidBodyPublisherMap;
     RigidBodyPublisherMap rigidBodyPublisherMap;
 
-    typedef std::shared_ptr<TriggerServiceHandler> TriggerServicePtr;
-    typedef std::map<int,TriggerServicePtr> TriggerServiceMap;
-    TriggerServiceMap triggerServiceMap;
+    typedef std::shared_ptr<EnableServiceHandler> EnableServicePtr;
+    typedef std::map<int,EnableServicePtr> EnableServiceMap;
+    EnableServiceMap enableServiceMap;
 
 public:
     RigidBodyPublishDispatcher(rclcpp::Node::SharedPtr &node, 

--- a/package.xml
+++ b/package.xml
@@ -36,9 +36,11 @@
   
   <depend>rclcpp</depend>
   <depend>tf2_ros</depend>
+
   <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>nav_msgs</build_export_depend>
-
+  <build_export_depend>std_srvs</build_export_depend>
+  
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,8 @@ target_link_libraries(${PROJECT_NAME}_mocap_node
   ${rclcpp_LIBRARIES}
   ${geometry_msgs_LIBRARIES}
   ${nav_msgs_LIBRARIES}
-  ${tf2_ros_LIBRARIES})
+  ${tf2_ros_LIBRARIES}
+  ${std_srvs_LIBRARIES})
 
 set_target_properties(${PROJECT_NAME}_mocap_node PROPERTIES
                       OUTPUT_NAME mocap_node PREFIX "")

--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -247,11 +247,21 @@ TriggerServiceHandler::TriggerServiceHandler(rclcpp::Node::SharedPtr &node, Publ
 {
   startServicePtr = node->create_service<std_srvs::srv::Trigger>(
     "/mocap_node/stream/start/" + config.childFrameId,
-    std::bind(&TriggerServiceHandler::startTriggerCallback, this, std::placeholders::_1, std::placeholders::_2));
+    [this](
+      const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+      std::shared_ptr<std_srvs::srv::Trigger::Response> response
+    ) {
+      startTriggerCallback(request, response);
+    });
 
   stopServicePtr = node->create_service<std_srvs::srv::Trigger>(
     "/mocap_node/stream/stop/" + config.childFrameId,
-    std::bind(&TriggerServiceHandler::stopTriggerCallback, this, std::placeholders::_1, std::placeholders::_2));
+    [this](
+      const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+      std::shared_ptr<std_srvs::srv::Trigger::Response> response
+    ) {
+      stopTriggerCallback(request, response);
+    });
 
   RCLCPP_INFO(rclcpp::get_logger("mocap_optitrack"), "Trigger service handlers created for %s", config.childFrameId.c_str());
 }

--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -230,8 +230,9 @@ void RigidBodyPublishDispatcher::publish(
   for (auto const& rigidBody : rigidBodies)
   {
     auto const& iter = rigidBodyPublisherMap.find(rigidBody.bodyId);
+    auto const& iter_trigger = triggerServiceMap.find(rigidBody.bodyId);
 
-    if (iter != rigidBodyPublisherMap.end())
+    if (iter != rigidBodyPublisherMap.end() && iter_trigger != triggerServiceMap.end() && (*iter_trigger->second).shouldPublishFrame())
     {
       (*iter->second).publish(time, rigidBody, logger);
     }
@@ -261,6 +262,7 @@ void TriggerServiceHandler::startTriggerCallback(
 {
   RCLCPP_INFO(rclcpp::get_logger("mocap_optitrack"), "Trigger service called to start");
   (void)request;
+  shouldPublish = true;
   response->success = true;
   response->message = "Triggered";
 }
@@ -271,6 +273,7 @@ void TriggerServiceHandler::stopTriggerCallback(
 {
   RCLCPP_INFO(rclcpp::get_logger("mocap_optitrack"), "Trigger service called to stop");
   (void)request;
+  shouldPublish = false;
   response->success = true;
   response->message = "Triggered";
 }

--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -246,7 +246,7 @@ TriggerServiceHandler::~TriggerServiceHandler()
 TriggerServiceHandler::TriggerServiceHandler(rclcpp::Node::SharedPtr &node, PublisherConfiguration const& config): logger_(node->get_logger()), config(config)
 {
   startServicePtr = node->create_service<std_srvs::srv::Trigger>(
-    "/mocap_node/stream/start/" + config.childFrameId,
+    "~/stream/start/" + config.childFrameId,
     [this](
       const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
       std::shared_ptr<std_srvs::srv::Trigger::Response> response
@@ -255,7 +255,7 @@ TriggerServiceHandler::TriggerServiceHandler(rclcpp::Node::SharedPtr &node, Publ
     });
 
   stopServicePtr = node->create_service<std_srvs::srv::Trigger>(
-    "/mocap_node/stream/stop/" + config.childFrameId,
+    "~/stream/stop/" + config.childFrameId,
     [this](
       const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
       std::shared_ptr<std_srvs::srv::Trigger::Response> response

--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -243,7 +243,7 @@ TriggerServiceHandler::~TriggerServiceHandler()
 {
 }
 
-TriggerServiceHandler::TriggerServiceHandler(rclcpp::Node::SharedPtr &node, PublisherConfiguration const& config)
+TriggerServiceHandler::TriggerServiceHandler(rclcpp::Node::SharedPtr &node, PublisherConfiguration const& config): logger_(node->get_logger())
 {
   startServicePtr = node->create_service<std_srvs::srv::Trigger>(
     "/mocap_node/stream/start/" + config.childFrameId,
@@ -262,15 +262,14 @@ TriggerServiceHandler::TriggerServiceHandler(rclcpp::Node::SharedPtr &node, Publ
     ) {
       stopTriggerCallback(request, response);
     });
-
-  RCLCPP_INFO(rclcpp::get_logger("mocap_optitrack"), "Trigger service handlers created for %s", config.childFrameId.c_str());
+  RCLCPP_INFO(logger_, "Trigger service handlers created for %s", config.childFrameId.c_str());
 }
 
 void TriggerServiceHandler::startTriggerCallback(
   const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
   std::shared_ptr<std_srvs::srv::Trigger::Response> response)
 {
-  RCLCPP_INFO(rclcpp::get_logger("mocap_optitrack"), "Trigger service called to start");
+  RCLCPP_INFO(logger_, "Trigger service called to start");
   (void)request;
   shouldPublish = true;
   response->success = true;
@@ -281,7 +280,7 @@ void TriggerServiceHandler::stopTriggerCallback(
   const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
   std::shared_ptr<std_srvs::srv::Trigger::Response> response)
 {
-  RCLCPP_INFO(rclcpp::get_logger("mocap_optitrack"), "Trigger service called to stop");
+  RCLCPP_INFO(logger_, "Trigger service called to stop");
   (void)request;
   shouldPublish = false;
   response->success = true;

--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -243,7 +243,7 @@ TriggerServiceHandler::~TriggerServiceHandler()
 {
 }
 
-TriggerServiceHandler::TriggerServiceHandler(rclcpp::Node::SharedPtr &node, PublisherConfiguration const& config): logger_(node->get_logger())
+TriggerServiceHandler::TriggerServiceHandler(rclcpp::Node::SharedPtr &node, PublisherConfiguration const& config): logger_(node->get_logger()), config(config)
 {
   startServicePtr = node->create_service<std_srvs::srv::Trigger>(
     "/mocap_node/stream/start/" + config.childFrameId,
@@ -262,6 +262,7 @@ TriggerServiceHandler::TriggerServiceHandler(rclcpp::Node::SharedPtr &node, Publ
     ) {
       stopTriggerCallback(request, response);
     });
+    
   RCLCPP_INFO(logger_, "Trigger service handlers created for %s", config.childFrameId.c_str());
 }
 
@@ -269,22 +270,23 @@ void TriggerServiceHandler::startTriggerCallback(
   const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
   std::shared_ptr<std_srvs::srv::Trigger::Response> response)
 {
-  RCLCPP_INFO(logger_, "Trigger service called to start");
+  
   (void)request;
   shouldPublish = true;
   response->success = true;
-  response->message = "Triggered";
+  response->message = "Start stream";
+  RCLCPP_INFO(logger_, "Start streaming %s", config.childFrameId.c_str());
 }
 
 void TriggerServiceHandler::stopTriggerCallback(
   const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
   std::shared_ptr<std_srvs::srv::Trigger::Response> response)
 {
-  RCLCPP_INFO(logger_, "Trigger service called to stop");
   (void)request;
   shouldPublish = false;
   response->success = true;
-  response->message = "Triggered";
+  response->message = "Stop stream";
+  RCLCPP_INFO(logger_, "Stop streaming %s", config.childFrameId.c_str());
 }
 
 } // namespace

--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -213,8 +213,8 @@ RigidBodyPublishDispatcher::RigidBodyPublishDispatcher(
 {
   for (auto const& config : configs)
   {
-    triggerServiceMap[config.rigidBodyId] = 
-      TriggerServicePtr(new TriggerServiceHandler(node, config));
+    enableServiceMap[config.rigidBodyId] = 
+      EnableServicePtr(new EnableServiceHandler(node, config));
 
     rigidBodyPublisherMap[config.rigidBodyId] = 
       RigidBodyPublisherPtr(new RigidBodyPublisher(node, natNetVersion, config));
@@ -230,63 +230,41 @@ void RigidBodyPublishDispatcher::publish(
   for (auto const& rigidBody : rigidBodies)
   {
     auto const& iter = rigidBodyPublisherMap.find(rigidBody.bodyId);
-    auto const& iter_trigger = triggerServiceMap.find(rigidBody.bodyId);
+    auto const& iter_service = enableServiceMap.find(rigidBody.bodyId);
 
-    if (iter != rigidBodyPublisherMap.end() && iter_trigger != triggerServiceMap.end() && (*iter_trigger->second).shouldPublishFrame())
+    if (iter != rigidBodyPublisherMap.end() && iter_service != enableServiceMap.end() && (*iter_service->second).shouldPublishFrame())
     {
       (*iter->second).publish(time, rigidBody, logger);
     }
   }
 }
 
-TriggerServiceHandler::~TriggerServiceHandler()
+EnableServiceHandler::~EnableServiceHandler()
 {
 }
 
-TriggerServiceHandler::TriggerServiceHandler(rclcpp::Node::SharedPtr &node, PublisherConfiguration const& config): logger_(node->get_logger()), config(config)
+EnableServiceHandler::EnableServiceHandler(rclcpp::Node::SharedPtr &node, PublisherConfiguration const& config): logger_(node->get_logger()), config(config)
 {
-  startServicePtr = node->create_service<std_srvs::srv::Trigger>(
-    "~/stream/start/" + config.childFrameId,
+  servicePtr = node->create_service<std_srvs::srv::SetBool>(
+    "~/stream/" + config.childFrameId,
     [this](
-      const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-      std::shared_ptr<std_srvs::srv::Trigger::Response> response
+      const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+      std::shared_ptr<std_srvs::srv::SetBool::Response> response
     ) {
-      startTriggerCallback(request, response);
-    });
-
-  stopServicePtr = node->create_service<std_srvs::srv::Trigger>(
-    "~/stream/stop/" + config.childFrameId,
-    [this](
-      const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-      std::shared_ptr<std_srvs::srv::Trigger::Response> response
-    ) {
-      stopTriggerCallback(request, response);
+      setBoolServiceCallback(request, response);
     });
     
   RCLCPP_INFO(logger_, "Trigger service handlers created for %s", config.childFrameId.c_str());
 }
 
-void TriggerServiceHandler::startTriggerCallback(
-  const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-  std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+void EnableServiceHandler::setBoolServiceCallback(
+  const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+  std::shared_ptr<std_srvs::srv::SetBool::Response> response)
 {
-  
-  (void)request;
-  shouldPublish = true;
+  shouldPublish = request->data;
   response->success = true;
-  response->message = "Start stream";
-  RCLCPP_INFO(logger_, "Start streaming %s", config.childFrameId.c_str());
-}
-
-void TriggerServiceHandler::stopTriggerCallback(
-  const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-  std::shared_ptr<std_srvs::srv::Trigger::Response> response)
-{
-  (void)request;
-  shouldPublish = false;
-  response->success = true;
-  response->message = "Stop stream";
-  RCLCPP_INFO(logger_, "Stop streaming %s", config.childFrameId.c_str());
+  response->message = "Stream " + config.childFrameId + " : " + (shouldPublish ? "enabled" : "disabled");
+  RCLCPP_INFO(logger_, ("Stream " + config.childFrameId + " : " + (shouldPublish ? "enabled" : "disabled")).c_str());
 }
 
 } // namespace

--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -213,6 +213,9 @@ RigidBodyPublishDispatcher::RigidBodyPublishDispatcher(
 {
   for (auto const& config : configs)
   {
+    triggerServiceMap[config.rigidBodyId] = 
+      TriggerServicePtr(new TriggerServiceHandler(node, config));
+
     rigidBodyPublisherMap[config.rigidBodyId] = 
       RigidBodyPublisherPtr(new RigidBodyPublisher(node, natNetVersion, config));
   }
@@ -235,5 +238,41 @@ void RigidBodyPublishDispatcher::publish(
   }
 }
 
+TriggerServiceHandler::~TriggerServiceHandler()
+{
+}
+
+TriggerServiceHandler::TriggerServiceHandler(rclcpp::Node::SharedPtr &node, PublisherConfiguration const& config)
+{
+  startServicePtr = node->create_service<std_srvs::srv::Trigger>(
+    "/mocap_node/stream/start/" + config.childFrameId,
+    std::bind(&TriggerServiceHandler::startTriggerCallback, this, std::placeholders::_1, std::placeholders::_2));
+
+  stopServicePtr = node->create_service<std_srvs::srv::Trigger>(
+    "/mocap_node/stream/stop/" + config.childFrameId,
+    std::bind(&TriggerServiceHandler::stopTriggerCallback, this, std::placeholders::_1, std::placeholders::_2));
+
+  RCLCPP_INFO(rclcpp::get_logger("mocap_optitrack"), "Trigger service handlers created for %s", config.childFrameId.c_str());
+}
+
+void TriggerServiceHandler::startTriggerCallback(
+  const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+  std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+{
+  RCLCPP_INFO(rclcpp::get_logger("mocap_optitrack"), "Trigger service called to start");
+  (void)request;
+  response->success = true;
+  response->message = "Triggered";
+}
+
+void TriggerServiceHandler::stopTriggerCallback(
+  const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+  std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+{
+  RCLCPP_INFO(rclcpp::get_logger("mocap_optitrack"), "Trigger service called to stop");
+  (void)request;
+  response->success = true;
+  response->message = "Triggered";
+}
 
 } // namespace


### PR DESCRIPTION
This PR implements start and stop trigger services for each optitrack object.

A `std::map` of handler classes is used to implement the trigger services dynamically for each defined object in the .yaml file, which is a copy of how the node handles publishing of the frames so it drops in nicely. 

The naming convention is to have services by the name of;
`/mocap_node/stream/start/<child_frame>`
`/mocap_node/stream/stop/<child_frame>`

The stop node just sets a flag in the handler class, which is checked in the for loop each time the node tries to publish the transform. The start also just sets this flag too.

The default behaviour is 'start' ensuring that this does not cause breaking changes.