### PR TITLE
Fix negative time crashes by dropping support for motive timestamp

### DIFF
--- a/include/mocap_optitrack/data_model.h
+++ b/include/mocap_optitrack/data_model.h
@@ -70,7 +70,6 @@ struct RigidBody
     Pose pose;
     float meanMarkerError;
     bool isTrackingValid;
-    double trackTimestamp;
 
     bool hasValidData() const;
 };

--- a/include/mocap_optitrack/rigid_body_publisher.h
+++ b/include/mocap_optitrack/rigid_body_publisher.h
@@ -59,14 +59,12 @@ public:
     Version const& natNetVersion, 
     PublisherConfiguration const& config);
   ~RigidBodyPublisher();
-  void publish(rclcpp::Time const& time, RigidBody const&, rclcpp::Logger);
+  void publish(rclcpp::Time const& time, RigidBody const&);
 
 private:
   PublisherConfiguration config;
 
   Version coordinatesVersion;
-
-  double timeDifference;	//For syncing optitrack clock to ROS clock
 
   tf2_ros::TransformBroadcaster tfPublisher;
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr posePublisher;
@@ -109,7 +107,7 @@ public:
     RigidBodyPublishDispatcher(rclcpp::Node::SharedPtr &node, 
         Version const& natNetVersion, 
         PublisherConfigurations const& configs);
-    void publish(rclcpp::Time const& time, std::vector<RigidBody> const& rigidBodies, rclcpp::Logger logger);
+    void publish(rclcpp::Time const& time, std::vector<RigidBody> const& rigidBodies);
 };
 
 } // namespace

--- a/src/mocap_node.cpp
+++ b/src/mocap_node.cpp
@@ -114,7 +114,7 @@ namespace mocap_optitrack
             // Maybe we got some data? If we did it would be in the form of one or more
             // rigid bodies in the data model
             const rclcpp::Time time = clock->now();
-            publishDispatcherPtr->publish(time, dataModel.dataFrame.rigidBodies, node->get_logger());
+            publishDispatcherPtr->publish(time, dataModel.dataFrame.rigidBodies);
 
             // Clear out the model to prepare for the next frame of data
             dataModel.clear();

--- a/src/natnet/natnet_messages.cpp
+++ b/src/natnet/natnet_messages.cpp
@@ -470,12 +470,6 @@ void DataFrameMessage::deserialize(
   }
   RCLCPP_DEBUG(logger, "Timestamp: %3.3f", timestamp);
 
-  // Loop over rigid bodies to add optitrack timestamp
-  for (auto& rigidBody : dataFrame->rigidBodies)
-  {
-    rigidBody.trackTimestamp = timestamp;
-  }
-
   // high res timestamps (version 3.0 and later)
   if (NatNetVersion >= mocap_optitrack::Version("3.0"))
   {

--- a/src/rigid_body_publisher.cpp
+++ b/src/rigid_body_publisher.cpp
@@ -125,7 +125,7 @@ RigidBodyPublisher::~RigidBodyPublisher()
 {
 }
 
-void RigidBodyPublisher::publish(rclcpp::Time const& time, RigidBody const& body, rclcpp::Logger logger)
+void RigidBodyPublisher::publish(rclcpp::Time const& time, RigidBody const& body)
 {
   // don't do anything if no new data was provided
   if (!body.hasValidData())
@@ -140,41 +140,18 @@ void RigidBodyPublisher::publish(rclcpp::Time const& time, RigidBody const& body
   }
 
   geometry_msgs::msg::PoseStamped pose = utilities::getRosPose(body, coordinatesVersion);
-  nav_msgs::msg::Odometry odom =  utilities::getRosOdom(body, coordinatesVersion);
-
-  double curTimeDifference = time.seconds() - body.trackTimestamp;
-
-  // If timeDifference is 0 it has not yet been set
-  if (timeDifference == 0){
-    RCLCPP_DEBUG(logger, "Initial clock sync: %.0f seconds", curTimeDifference);
-    timeDifference = curTimeDifference;
-  }
-
-  // Clock sync can be improved if the current timeDifference is the lowest seen
-  if (curTimeDifference < timeDifference){
-    RCLCPP_DEBUG(logger, "Improving clock sync by %.5f seconds", timeDifference - curTimeDifference);
-    timeDifference = curTimeDifference;
-  }
-
-  // Calculate correct timestamp using time difference
-  double corStamp = body.trackTimestamp + timeDifference;
-
-  pose.header.stamp = rclcpp::Time((int)corStamp, (corStamp-floor(corStamp)) * 1000000000 );
-  odom.header.stamp = rclcpp::Time((int)corStamp, (corStamp-floor(corStamp)) * 1000000000 );
 
   if (config.publishPose)
   {
+    pose.header.stamp = time;
     pose.header.frame_id = config.parentFrameId;
     posePublisher->publish(pose);
   }
 
-  tf2::Quaternion q(pose.pose.orientation.x,
-                   pose.pose.orientation.y,
-                   pose.pose.orientation.z,
-                   pose.pose.orientation.w);
-
   if (config.publishOdom)
   {
+    nav_msgs::msg::Odometry odom = utilities::getRosOdom(body, coordinatesVersion);
+    odom.header.stamp = time;
     odom.header.frame_id = config.parentFrameId;
     odom.child_frame_id = config.childFrameId;
     odomPublisher->publish(odom);
@@ -183,6 +160,10 @@ void RigidBodyPublisher::publish(rclcpp::Time const& time, RigidBody const& body
   // publish 2D pose
   if (config.publishPose2d)
   {
+    tf2::Quaternion q(pose.pose.orientation.x,
+                      pose.pose.orientation.y,
+                      pose.pose.orientation.z,
+                      pose.pose.orientation.w);
     geometry_msgs::msg::Pose2D pose2d;
     pose2d.x = pose.pose.position.x;
     pose2d.y = pose.pose.position.y;
@@ -223,8 +204,7 @@ RigidBodyPublishDispatcher::RigidBodyPublishDispatcher(
 
 void RigidBodyPublishDispatcher::publish(
   rclcpp::Time const& time, 
-  std::vector<RigidBody> const& rigidBodies,
-  rclcpp::Logger logger
+  std::vector<RigidBody> const& rigidBodies
   )
 {
   for (auto const& rigidBody : rigidBodies)
@@ -234,7 +214,7 @@ void RigidBodyPublishDispatcher::publish(
 
     if (iter != rigidBodyPublisherMap.end() && iter_service != enableServiceMap.end() && (*iter_service->second).shouldPublishFrame())
     {
-      (*iter->second).publish(time, rigidBody, logger);
+      (*iter->second).publish(time, rigidBody);
     }
   }
 }


### PR DESCRIPTION
The Optitrack driver seemed to crash on initialization every few tries, due to a `cannot store a negative time point in rclcpp::Time` error.

This was caused by a piece of code attempting to sync the ROS timestamp with the incoming Motive timestamp. Unfortunately, the incoming timestamps seemed to have invalid values (more notes and logs [here](https://linear.app/acumino/issue/ACU-2278/debug-optitrack-disconnects)), which were causing the driver to occasionally crash.

I checked this in a bit more detail and compared with the official SDK, and I believe there are errors in incoming packet parsing. NatNet 4.x seems to have included another data section between the rigid bodies and timestamps, so the timestamp might be messed up because we are actually parsing some other random data block.
I made a weak attempt to parse the missing block and failed (I kind of don't want to spend more time on this since I'd like to replace the whole driver anyway).

The conflicting timestamp is currently only used to stamp the raw `pose` (not TF) and `odom` data - both of which we don't use. In this PR I therefore removed support for Motive timestamps and instead just use the driver (ROS) stamp. This stamp is used already in the TF publisher, so the change kind of unifies the published data timing.

For reference, [this](https://github.com/acumino-ai/mocap_optitrack/commit/023b897e6a097125619c221c2bddddabf156e3fa) is the original commit that introduced the Motive timestamp changes 4 years ago.